### PR TITLE
Fix casing for dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,10 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
 ]
+
 dependencies = [
-    "pytelegrambotapi>=4.30.0,<5",
-    "python-dotenv>=1.2.1,<2",
+    "pyTelegramBotAPI>=4.30.0,<5",
+    "python-dotenv>=1.2.1,<2"
 ]
 
 [tool.uv]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected the Telegram Bot API dependency package naming to match the official casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->